### PR TITLE
Allows p3dn.24xlarge (and maybe other instance types?)

### DIFF
--- a/spotty/providers/aws/config/validation.py
+++ b/spotty/providers/aws/config/validation.py
@@ -80,6 +80,6 @@ def is_nitro_instance(instance_type):
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances
     nitro_prefixes = ['a1', 'c5', 'c5d', 'c5n', 'i3en', 'm5', 'm5a', 'm5ad', 'm5d', 'r5', 'r5a', 'r5ad', 'r5d',
                          't3', 't3a', 'z1d']
-    nitro_types = ['p3dn.24xlarge', 'i3.metal', 'u-6tb1.metal', 'u-9tb1.metal', 'u-12tb1.metal']
+    nitro_types = ['i3.metal', 'u-6tb1.metal', 'u-9tb1.metal', 'u-12tb1.metal']
 
     return any(instance_type.startswith(prefix + '.') for prefix in nitro_prefixes) or instance_type in nitro_types

--- a/spotty/providers/aws/deployment/cf_templates/data/instance.yaml
+++ b/spotty/providers/aws/deployment/cf_templates/data/instance.yaml
@@ -203,7 +203,13 @@ Resources:
 
                 for i in ${!!MOUNT_DIRS[*]}
                 do
-                  DEVICE=/dev/xvd${!DEVICE_LETTERS[$i]}
+                if [ -e /dev/nvme1n1 ]
+                  then
+                    DEVICE=/dev/nvme1n1
+                  else
+                    DEVICE=/dev/xvd${!DEVICE_LETTERS[$i]}
+                fi
+                  
                   MOUNT_DIR=${!MOUNT_DIRS[$i]}
 
                   blkid -o value -s TYPE $DEVICE || mkfs -t ext4 $DEVICE


### PR DESCRIPTION
This fix works for us to allow p3dn.24xlarge. Might want to test other nitro types though.