### PR TITLE
Inbound IP whitelist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='spotty',
           'cfn_flip',  # to work with CloudFormation templates
           'schema',
           'chevron',
+          'netaddr' # validates configuration IP addresses
       ],
       tests_require=['moto'],
       test_suite='tests',

--- a/spotty/providers/aws/cfn_templates/instance/data/template.yaml
+++ b/spotty/providers/aws/cfn_templates/instance/data/template.yaml
@@ -88,15 +88,7 @@ Resources:
           IpProtocol: -1
           FromPort: 0
           ToPort: 65535
-      SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
-          IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-        - CidrIpv6: ::/0
-          IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
+      SecurityGroupIngress: []
 
   PreparingInstanceSignal:
     Type: AWS::CloudFormation::WaitCondition

--- a/spotty/providers/aws/cfn_templates/instance/template.py
+++ b/spotty/providers/aws/cfn_templates/instance/template.py
@@ -20,7 +20,6 @@ from spotty.providers.aws.resources.volume import Volume
 from spotty.providers.aws.config.instance_config import InstanceConfig
 from spotty.providers.aws.config.ebs_volume import EbsVolume
 from spotty.providers.aws.helpers.logs import get_logs_s3_path
-from netaddr import IPNetwork
 
 
 def prepare_instance_template(ec2, instance_config: InstanceConfig, docker_commands: DockerCommands,
@@ -58,11 +57,11 @@ def prepare_instance_template(ec2, instance_config: InstanceConfig, docker_comma
         del template['Resources']['InstanceLaunchTemplate']['Properties']['LaunchTemplateData']['SecurityGroupIds']
 
     # add ports to the security group for the user-defined inbound IP
-    ipnetwork = IPNetwork(instance_config.instance_inbound_ip)
-    cidr_ip = 'CidrIpv6' if ipnetwork.version == 6 else 'CidrIp'
+    inbound_ip = instance_config.inbound_ip
+    cidr_ip = 'CidrIpv6' if inbound_ip == 6 else 'CidrIp'
     for port in [22] + instance_config.ports:
         template['Resources']['InstanceSecurityGroup']['Properties']['SecurityGroupIngress'] += [{
-            cidr_ip: str(ipnetwork),
+            cidr_ip: str(inbound_ip),
             'IpProtocol': 'tcp',
             'FromPort': port,
             'ToPort': port,

--- a/spotty/providers/aws/cfn_templates/instance/template.py
+++ b/spotty/providers/aws/cfn_templates/instance/template.py
@@ -20,6 +20,7 @@ from spotty.providers.aws.resources.volume import Volume
 from spotty.providers.aws.config.instance_config import InstanceConfig
 from spotty.providers.aws.config.ebs_volume import EbsVolume
 from spotty.providers.aws.helpers.logs import get_logs_s3_path
+from netaddr import IPNetwork
 
 
 def prepare_instance_template(ec2, instance_config: InstanceConfig, docker_commands: DockerCommands,
@@ -56,20 +57,16 @@ def prepare_instance_template(ec2, instance_config: InstanceConfig, docker_comma
             }]
         del template['Resources']['InstanceLaunchTemplate']['Properties']['LaunchTemplateData']['SecurityGroupIds']
 
-    # add ports to the security group
-    for port in instance_config.ports:
-        if port != 22:
-            template['Resources']['InstanceSecurityGroup']['Properties']['SecurityGroupIngress'] += [{
-                'CidrIp': '0.0.0.0/0',
-                'IpProtocol': 'tcp',
-                'FromPort': port,
-                'ToPort': port,
-            }, {
-                'CidrIpv6': '::/0',
-                'IpProtocol': 'tcp',
-                'FromPort': port,
-                'ToPort': port,
-            }]
+    # add ports to the security group for the user-defined inbound IP
+    ipnetwork = IPNetwork(instance_config.instance_inbound_ip)
+    cidr_ip = 'CidrIpv6' if ipnetwork.version == 6 else 'CidrIp'
+    for port in [22] + instance_config.ports:
+        template['Resources']['InstanceSecurityGroup']['Properties']['SecurityGroupIngress'] += [{
+            cidr_ip: str(ipnetwork),
+            'IpProtocol': 'tcp',
+            'FromPort': port,
+            'ToPort': port,
+        }]
 
     if instance_config.is_spot_instance:
         # set maximum price

--- a/spotty/providers/aws/config/instance_config.py
+++ b/spotty/providers/aws/config/instance_config.py
@@ -75,7 +75,11 @@ class InstanceConfig(AbstractInstanceConfig):
     @property
     def managed_policy_arns(self) -> list:
         return self._params['managedPolicyArns']
-    
+
     @property
     def instance_profile_arn(self) -> str:
         return self._params['instanceProfileArn']
+
+    @property
+    def inbound_ip(self) -> str:
+        return self._params['inboundIp']

--- a/spotty/providers/aws/config/validation.py
+++ b/spotty/providers/aws/config/validation.py
@@ -30,6 +30,7 @@ def validate_instance_parameters(params: dict):
                                              ),
         Optional('managedPolicyArns', default=[]): [str],
         Optional('instanceProfileArn', default=None): str,
+        Optional('inboundIp', default="0.0.0.0/0"): str
     }
 
     volumes_checks = [

--- a/spotty/providers/aws/config/validation.py
+++ b/spotty/providers/aws/config/validation.py
@@ -1,5 +1,6 @@
 import os
 from schema import Schema, Optional, And, Regex, Or, Use
+from netaddr import IPNetwork
 from spotty.config.validation import validate_config, get_instance_parameters_schema, has_prefix
 
 
@@ -30,7 +31,8 @@ def validate_instance_parameters(params: dict):
                                              ),
         Optional('managedPolicyArns', default=[]): [str],
         Optional('instanceProfileArn', default=None): str,
-        Optional('inboundIp', default="0.0.0.0/0"): str
+        Optional('inboundIp', default="0.0.0.0/0"): Use(IPNetwork, error='"inboundIp" should be a valid IP '
+                                                                         'address or CIDR range')
     }
 
     volumes_checks = [

--- a/tests/providers/aws/config/instance_config_validation.py
+++ b/tests/providers/aws/config/instance_config_validation.py
@@ -28,6 +28,7 @@ class TestBucketResource(unittest.TestCase):
             'spotInstance': False,
             'subnetId': '',
             'volumes': [],
+            'inboundIp': "0.0.0.0/0"
         }
 
         self.assertEqual(expected_params, validate_instance_parameters(required_params))


### PR DESCRIPTION
New config param `instances.parameters.inboundIp`.

Allows users to specify an inbound IP address or range, which is then
used to whitelist all ports, including 22, in the instance's security
group. By default this is set to 0.0.0.0/0 and therefore not
whitelisted.

Resolves #96 